### PR TITLE
Add ArgoCD configuration files

### DIFF
--- a/argocd/application.yaml
+++ b/argocd/application.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-application
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ignacioballester/my-new-repository.git
+    targetRevision: HEAD
+    path: kubernetes/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: my-application
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  revisionHistoryLimit: 5

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -1,0 +1,47 @@
+server:
+  extraArgs:
+    - --insecure
+  ingress:
+    enabled: true
+    hosts:
+      - argocd.example.com
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+
+repoServer:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+applicationController:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
+
+redis:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+
+dex:
+  enabled: true
+  
+notifications:
+  enabled: true
+
+global:
+  image:
+    tag: v2.6.7


### PR DESCRIPTION
This PR adds ArgoCD configuration files:

1. `application.yaml` - Defines an ArgoCD Application resource that specifies how to deploy our application
2. `values.yaml` - Contains configuration values for the ArgoCD Helm chart

These configurations provide:
- Automated syncing with pruning and self-healing
- Resource limits for ArgoCD components
- Ingress configuration
- Dex and notifications setup
- Specific ArgoCD version (v2.6.7)

The application is configured to deploy from the `kubernetes/manifests` directory of this repository to a namespace called `my-application` in the cluster.